### PR TITLE
Small fix in goDeep for Array fieldtypes

### DIFF
--- a/Fetch/Fetch.php
+++ b/Fetch/Fetch.php
@@ -120,7 +120,7 @@ class Fetch
         return collect($item)->map(function ($value, $key) {
             if (is_array($value)) {
                 $array = collect($value)->map(function ($value) {
-                    return $this->goDeep($value);
+                    return is_string($value) && strlen($value) == 36 ? $this->goDeep($value) : $value;
                 });
 
                 return $this->containsAssoc($array) ? $array : $array->collapse();
@@ -137,7 +137,7 @@ class Fetch
     {
         if (Asset::find($item)) {
             $asset = Asset::find($item)->manipulate()->build();
-            
+
             return URL::makeAbsolute($asset);
         }
 


### PR DESCRIPTION
Array type fields used to show values as objects, hence the modification. I've done some tests and it looks good. Please review if I've done anything wrong.